### PR TITLE
Fix the missing return statements for linux & windows 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -92,7 +92,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "Babel"
@@ -187,7 +187,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode-backport = ["unicodedata2"]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -267,7 +267,7 @@ requests = "*"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.2"
+version = "1.0.4"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -377,9 +377,9 @@ python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "Jinja2"
@@ -422,7 +422,7 @@ python-versions = "*"
 six = "*"
 
 [package.extras]
-restructuredtext = ["rst2ansi"]
+restructuredText = ["rst2ansi"]
 
 [[package]]
 name = "MarkupSafe"
@@ -769,7 +769,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
@@ -985,7 +985,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-requests"
-version = "2.28.11.4"
+version = "2.28.11.5"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -1004,7 +1004,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.25.3"
+version = "1.26.25.4"
 description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
@@ -1326,8 +1326,8 @@ ec2-metadata = [
     {file = "ec2_metadata-2.10.0-py3-none-any.whl", hash = "sha256:a8a2f6fd1f36a58c8453d8e9f8c874e7ee6ac7149bdfb2e452218f40abc5a55c"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.2-py3-none-any.whl", hash = "sha256:c22f11ec6a10d2b453871c5c5fe887436c4d1961324ce9090f2ca6ddc4180c27"},
-    {file = "exceptiongroup-1.0.2.tar.gz", hash = "sha256:a31cd183c3dea02e617aab5153588d5f7258a77b51f0ef41b3815ae8a0d0f695"},
+    {file = "exceptiongroup-1.0.4-py3-none-any.whl", hash = "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828"},
+    {file = "exceptiongroup-1.0.4.tar.gz", hash = "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"},
 ]
 execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
@@ -1915,16 +1915,16 @@ types-aiofiles = [
     {file = "types_aiofiles-22.1.0.3-py3-none-any.whl", hash = "sha256:c12668e29307ce06f751dbe02960a9fe6a3e3d9055911ca254839e8e9a78553f"},
 ]
 types-requests = [
-    {file = "types-requests-2.28.11.4.tar.gz", hash = "sha256:d4f342b0df432262e9e326d17638eeae96a5881e78e7a6aae46d33870d73952e"},
-    {file = "types_requests-2.28.11.4-py3-none-any.whl", hash = "sha256:bdb1f9811e53d0642c8347b09137363eb25e1a516819e190da187c29595a1df3"},
+    {file = "types-requests-2.28.11.5.tar.gz", hash = "sha256:a7df37cc6fb6187a84097da951f8e21d335448aa2501a6b0a39cbd1d7ca9ee2a"},
+    {file = "types_requests-2.28.11.5-py3-none-any.whl", hash = "sha256:091d4a5a33c1b4f20d8b1b952aa8fa27a6e767c44c3cf65e56580df0b05fd8a9"},
 ]
 types-ujson = [
     {file = "types-ujson-5.5.0.tar.gz", hash = "sha256:74bc0ec76e3caf3682625703aad4aa9999327517e39afae67bb5aa3100a39bb8"},
     {file = "types_ujson-5.5.0-py3-none-any.whl", hash = "sha256:6051e6b80d71382f1f85b0f97b475d84621eae3e2789ed24c5721f784b0846e1"},
 ]
 types-urllib3 = [
-    {file = "types-urllib3-1.26.25.3.tar.gz", hash = "sha256:1807b87b8ee1ae0226813ba2c52330eff20fb2bf6359b1de24df08eb3090e442"},
-    {file = "types_urllib3-1.26.25.3-py3-none-any.whl", hash = "sha256:a188c24fc61a99658c8c324c8dd7419f5b91a0d89df004e5f576869122c1db55"},
+    {file = "types-urllib3-1.26.25.4.tar.gz", hash = "sha256:eec5556428eec862b1ac578fb69aab3877995a99ffec9e5a12cf7fbd0cc9daee"},
+    {file = "types_urllib3-1.26.25.4-py3-none-any.whl", hash = "sha256:ed6b9e8a8be488796f72306889a06a3fc3cb1aa99af02ab8afb50144d7317e49"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},

--- a/tests/hardwares/test_energy.py
+++ b/tests/hardwares/test_energy.py
@@ -16,8 +16,8 @@ def test_power_should_convert_watt_hours_to_co2g():
 
 
 def test_energy_should_convert_watt_hours_to_co2g():
-    watts = 50
-    watt_hours_expected = 0.833
+    watts = 45
+    watt_hours_expected = 0.75
     one_minute_ago = datetime.datetime.now() - datetime.timedelta(seconds=60)
     previous_energy_measurement_time = one_minute_ago
 

--- a/tracarbon/hardwares/sensors.py
+++ b/tracarbon/hardwares/sensors.py
@@ -58,10 +58,10 @@ class EnergyConsumption(Sensor):
         if platform == "Darwin":
             return MacEnergyConsumption()
         if platform == "Linux":
-            LinuxEnergyConsumption()
+            return LinuxEnergyConsumption()
         if platform == "Windows":
-            WindowsEnergyConsumption()
-        raise TracarbonException(f"This platform {platform} is not yet implemented.")
+            return WindowsEnergyConsumption()
+        raise TracarbonException(f"This {platform} hardware is not yet implemented.")
 
 
 class MacEnergyConsumption(EnergyConsumption):
@@ -100,7 +100,7 @@ class LinuxEnergyConsumption(EnergyConsumption):
             return Power.watts_from_microjoules(
                 microjoules=await HardwareInfo.get_rapl_power_usage()
             )
-        raise NotImplementedError("Linux platform is not yet supported.")
+        raise TracarbonException(f"This Linux hardware is not yet supported.")
 
 
 class WindowsEnergyConsumption(EnergyConsumption):
@@ -114,7 +114,7 @@ class WindowsEnergyConsumption(EnergyConsumption):
 
         :return: the sensor metric.
         """
-        raise NotImplementedError("Windows platform is not yet supported.")
+        raise TracarbonException("This Windows hardware is not yet supported.")
 
 
 class AWSEC2EnergyConsumption(EnergyConsumption):


### PR DESCRIPTION
# Description
- Fix the missing `return` statements in `Linux` and `Windows` sensors

# Related Issue(s)
- closes #88 
