### PR TITLE
Add support for multiple packages for RAPL sensor

### DIFF
--- a/tests/hardwares/test_rapl.py
+++ b/tests/hardwares/test_rapl.py
@@ -29,17 +29,17 @@ async def test_get_rapl_power_usage():
         return rapl_result.energy_uj
 
     rapl_results.sort(key=by_energy_uj)
-    assert rapl_results[0].name == "core"
+    assert rapl_results[0].name == "T1T0-core"
     assert rapl_results[0].energy_uj == 3.0
-    assert rapl_results[1].name == "dram"
+    assert rapl_results[1].name == "T1T1-dram"
     assert rapl_results[1].energy_uj == 2433.0
-    assert rapl_results[2].name == "package-1"
+    assert rapl_results[2].name == "T1-package-1"
     assert rapl_results[2].energy_uj == 20232.0
-    assert rapl_results[3].name == "dram"
+    assert rapl_results[3].name == "T0T1-dram"
     assert rapl_results[3].energy_uj == 2592370025.0
-    assert rapl_results[4].name == "package-0"
+    assert rapl_results[4].name == "T0-package-0"
     assert rapl_results[4].energy_uj == 24346753748.0
-    assert rapl_results[5].name == "core"
+    assert rapl_results[5].name == "T0T0-core"
     assert rapl_results[5].energy_uj == 43725162336.0
 
 
@@ -51,8 +51,12 @@ async def test_get_rapl_power_wrap_around_when_0():
     two_seconds_ago = datetime.datetime.now() - datetime.timedelta(seconds=2)
     rapl_separator_for_windows = "T"
     rapl_results = dict()
-    rapl_results["package-0"] = RAPLResult(name="package", energy_uj=2, max_energy_uj=70000, timestamp=two_seconds_ago)
-    rapl_results["core"] = RAPLResult(name="core", energy_uj=1, max_energy_uj=70000, timestamp=two_seconds_ago)
+    rapl_results["T0-package-0"] = RAPLResult(
+        name="T0-package-0", energy_uj=2, max_energy_uj=70000, timestamp=two_seconds_ago
+    )
+    rapl_results["T0T0-core"] = RAPLResult(
+        name="T0T0-core", energy_uj=1, max_energy_uj=70000, timestamp=two_seconds_ago
+    )
     rapl = RAPL(path=path, rapl_separator=rapl_separator_for_windows, rapl_results=rapl_results)
     host_energy_usage_expected = 35
     cpu_energy_usage_expected = 35
@@ -72,10 +76,12 @@ async def test_get_total_uj_one_call():
     rapl_separator_for_windows = "T"
     one_minute_ago = datetime.datetime.now() - datetime.timedelta(seconds=60)
     rapl_results = dict()
-    rapl_results["package-0"] = RAPLResult(
-        name="package", energy_uj=50000, max_energy_uj=70000, timestamp=one_minute_ago
+    rapl_results["T0-package-0"] = RAPLResult(
+        name="T0-package-0", energy_uj=50000, max_energy_uj=70000, timestamp=one_minute_ago
     )
-    rapl_results["core"] = RAPLResult(name="core", energy_uj=40000, max_energy_uj=70000, timestamp=one_minute_ago)
+    rapl_results["T0T0-core"] = RAPLResult(
+        name="T0T0-core", energy_uj=40000, max_energy_uj=70000, timestamp=one_minute_ago
+    )
     rapl = RAPL(path=path, rapl_separator=rapl_separator_for_windows, rapl_results=rapl_results)
     host_energy_usage_expected = 0.33
     cpu_energy_usage_expected = 0.5
@@ -85,3 +91,48 @@ async def test_get_total_uj_one_call():
     assert round(energy_report.host_energy_usage, 2) == host_energy_usage_expected
     assert round(energy_report.cpu_energy_usage, 2) == cpu_energy_usage_expected
     assert energy_report.memory_energy_usage is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.linux
+@pytest.mark.darwin
+async def test_results_with_two_packages_are_correctly_computed():
+    path = f"{pathlib.Path(__file__).parent.resolve()}/data/intel-rapl"
+    rapl_separator_for_windows = "T"
+
+    one_milliwatt = 60000
+
+    one_minute_ago = datetime.datetime.now() - datetime.timedelta(seconds=60)
+    rapl_results = dict()
+    rapl_results["T0-package-0"] = RAPLResult(
+        name="T0-package-0", energy_uj=24346753748 - one_milliwatt, max_energy_uj=65532610987, timestamp=one_minute_ago
+    )
+    rapl_results["T0T0-core"] = RAPLResult(
+        name="T0T0-core", energy_uj=43725162336 - one_milliwatt, max_energy_uj=65532610987, timestamp=one_minute_ago
+    )
+    rapl_results["T0T1-dram"] = RAPLResult(
+        name="T0T1-dram", energy_uj=2592370025 - one_milliwatt, max_energy_uj=65532610987, timestamp=one_minute_ago
+    )
+
+    rapl_results["T1-package-1"] = RAPLResult(
+        name="T1-package-1", energy_uj=20232 - one_milliwatt, max_energy_uj=65532610987, timestamp=one_minute_ago
+    )
+    rapl_results["T1T0-core"] = RAPLResult(
+        name="T1T0-core", energy_uj=65532610987 - one_milliwatt + 3, max_energy_uj=65532610987, timestamp=one_minute_ago
+    )
+    rapl_results["T1T1-dram"] = RAPLResult(
+        name="T1T1-dram", energy_uj=2433 - one_milliwatt, max_energy_uj=65532610987, timestamp=one_minute_ago
+    )
+
+    rapl = RAPL(path=path, rapl_separator=rapl_separator_for_windows, rapl_results=rapl_results)
+
+    host_energy_usage_expected = 4
+    cpu_energy_usage_expected = 2
+    memory_energy_usage_expected = 2
+
+    energy_report = await rapl.get_energy_report()
+    energy_report.convert_unit(EnergyUsageUnit.MILLIWATT)
+    assert round(energy_report.host_energy_usage, 2) == host_energy_usage_expected
+    assert round(energy_report.cpu_energy_usage, 2) == cpu_energy_usage_expected
+    assert round(energy_report.memory_energy_usage, 2) == memory_energy_usage_expected
+    assert energy_report.gpu_energy_usage is None

--- a/tracarbon/hardwares/rapl.py
+++ b/tracarbon/hardwares/rapl.py
@@ -1,6 +1,7 @@
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -76,8 +77,10 @@ class RAPL(BaseModel):
             if not self.file_list:
                 self.get_rapl_files_list()
             for file_path in self.file_list:
+                name_prefix = Path(file_path).name.replace("intel-rapl", "")
                 async with aiofiles.open(f"{file_path}/name", "r") as rapl_name:
                     name = await rapl_name.read()
+                    name = f"{name_prefix}-{name}"
                     async with aiofiles.open(f"{file_path}/energy_uj", "r") as rapl_energy:
                         energy_uj = float(await rapl_energy.read())
                     async with aiofiles.open(f"{file_path}/max_energy_range_uj", "r") as rapl_max_energy:


### PR DESCRIPTION
# Description
This fixes the issue of having wrong results on servers with multiple CPUs as described in #391 

# Related Issue(s)
- closes #391

# Documentation
The fix is to prefix the name with the "id" of the package, which is taken from the parent directory name of the file. This won't cause issues with summing up values for the report, since it uses checks like `"package" in result.name`, but it fixes the issue with the computation of the differences, that confuse the values of `cpu`, `dram` and so on of different CPUs for being from the same CPU.
