### PR TITLE
Stabilize Prometheus container metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,25 @@ The environment variables can be set from an environment file `.env`.
 tracarbon run
 ```
 
+**Prometheus with Kubernetes containers**
+
+```sh
+tracarbon run --exporter-name Prometheus --containers
+```
+
+With the default metric prefix, container metrics are exposed with these Prometheus names:
+
+| **Metric** | **Labels** |
+| ---------- | ---------- |
+| tracarbon_energy_consumption_kubernetes_total | pod_name, pod_namespace, container_name, platform, containers, location, units |
+| tracarbon_energy_consumption_kubernetes_cpu | pod_name, pod_namespace, container_name, platform, containers, location, units |
+| tracarbon_energy_consumption_kubernetes_memory | pod_name, pod_namespace, container_name, platform, containers, location, units |
+| tracarbon_carbon_emission_kubernetes_total | pod_name, pod_namespace, container_name, platform, containers, location, source, units |
+| tracarbon_carbon_emission_kubernetes_cpu | pod_name, pod_namespace, container_name, platform, containers, location, source, units |
+| tracarbon_carbon_emission_kubernetes_memory | pod_name, pod_namespace, container_name, platform, containers, location, source, units |
+
+Zero values are exported. If Kubernetes returns no pod metrics, the CLI logs `No Kubernetes container metrics were collected.` Host metrics are still exported.
+
 **API**
 
 ```python
@@ -111,7 +130,7 @@ tracarbon.stop()
 with tracarbon:
     # Your code
 
-report = tracarbon.report() # Get the report
+report = tracarbon.report # Get the report
 ```
 
 ## 💻 Development

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -28,9 +28,25 @@ Run Tracarbon CLI with the Datadog exporter:
 
 >>> TRACARBON_CO2SIGNAL_API_KEY=API_KEY DATADOG_API_KEY=DATADOG_API_KEY DATADOG_APP_KEY=DATADOG_APP_KEY tracarbon run --exporter-name Datadog
 
-Run Tracarbon CLI on LinuxHardware with Kubernetes send send the metrics to Prometheus:
+Run Tracarbon CLI on Linux hardware with Kubernetes and send the metrics to Prometheus:
 
 >>> tracarbon run --exporter-name Prometheus --containers
+
+With the default metric prefix, container metrics are exposed with these Prometheus names:
+
+===============================================  ====================================================================
+Metric                                           Labels
+===============================================  ====================================================================
+tracarbon_energy_consumption_kubernetes_total    pod_name, pod_namespace, container_name, platform, containers, location, units
+tracarbon_energy_consumption_kubernetes_cpu      pod_name, pod_namespace, container_name, platform, containers, location, units
+tracarbon_energy_consumption_kubernetes_memory   pod_name, pod_namespace, container_name, platform, containers, location, units
+tracarbon_carbon_emission_kubernetes_total       pod_name, pod_namespace, container_name, platform, containers, location, source, units
+tracarbon_carbon_emission_kubernetes_cpu         pod_name, pod_namespace, container_name, platform, containers, location, source, units
+tracarbon_carbon_emission_kubernetes_memory      pod_name, pod_namespace, container_name, platform, containers, location, source, units
+===============================================  ====================================================================
+
+Zero values are exported. If Kubernetes returns no pod metrics, the CLI logs
+``No Kubernetes container metrics were collected.`` Host metrics are still exported.
 
 Run the code
 ============

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -70,3 +70,24 @@ def test_run_metrics_should_be_ok(mocker, caplog):
     assert "start_time" in caplog.text
     assert "end_time" in caplog.text
     assert "Report" in caplog.text
+
+
+@pytest.mark.darwin
+def test_run_metrics_warns_when_containers_collect_no_kubernetes_metrics(mocker, caplog):
+    exporter = "Stdout"
+    mocker.patch.object(
+        Country,
+        "get_location",
+        return_value=Country(name="fr", co2g_kwh=50.0),
+    )
+    mocker.patch.object(config, "load_kube_config", return_value=None)
+    mocker.patch.object(
+        MacEnergyConsumption,
+        "get_energy_usage",
+        return_value=EnergyUsage(cpu_energy_usage=15.0, memory_energy_usage=12.0),
+    )
+    mocker.patch.object(Kubernetes, "get_pods_usage", return_value=[])
+
+    run_metrics(exporter_name=exporter, running=False, containers=True)
+
+    assert "No Kubernetes container metrics were collected." in caplog.text

--- a/tests/exporters/test_prometheus_exporter.py
+++ b/tests/exporters/test_prometheus_exporter.py
@@ -14,10 +14,14 @@ def test_prometheus_exporter(mocker):
     memory_value = 70
     mock_memory_value = ["0", "0", memory_value]
     mocker.patch.object(psutil, "virtual_memory", return_value=mock_memory_value)
+    zero_value = 0
     expected_metric_1 = "gauge:tracarbon_test_metric_1"
 
     async def get_memory_usage() -> float:
         return psutil.virtual_memory()[2]
+
+    async def get_zero_value() -> float:
+        return zero_value
 
     mocker.patch.object(
         Country,
@@ -29,7 +33,12 @@ def test_prometheus_exporter(mocker):
         value=get_memory_usage,
         tags=[Tag(key="test", value="tags")],
     )
-    metric_generators = [MetricGenerator(metrics=[memory_metric])]
+    zero_metric = Metric(
+        name="zero_metric",
+        value=get_zero_value,
+        tags=[Tag(key="test", value="tags")],
+    )
+    metric_generators = [MetricGenerator(metrics=[memory_metric, zero_metric])]
     exporter = PrometheusExporter(
         quit=True,
         metric_generators=metric_generators,
@@ -47,3 +56,12 @@ def test_prometheus_exporter(mocker):
     assert exporter.metric_report["test_metric_1"].minimum < sys.float_info.max
     assert exporter.metric_report["test_metric_1"].maximum > 0
     assert exporter.metric_report["test_metric_1"].call_count == 1
+    assert exporter.metric_report["zero_metric"].total == zero_value
+    assert exporter.metric_report["zero_metric"].call_count == 1
+
+
+def test_prometheus_exporter_can_be_initialized_more_than_once(mocker):
+    mocker.patch("tracarbon.exporters.prometheus_exporter.start_http_server")
+
+    PrometheusExporter(quit=True, metric_generators=[], address="127.0.0.1", port=0)
+    PrometheusExporter(quit=True, metric_generators=[], address="127.0.0.1", port=0)

--- a/tracarbon/cli/__init__.py
+++ b/tracarbon/cli/__init__.py
@@ -123,6 +123,8 @@ def run_metrics(
         logger.exception(f"Error in Tracarbon execution: {e}")
 
     if tracarbon:
+        if containers and not any("_kubernetes_" in metric_name for metric_name in tracarbon.report.metric_report):
+            logger.warning("No Kubernetes container metrics were collected.")
         logger.info(f"Tracarbon CLI exited. Tracarbon report: {tracarbon.report}")
     else:
         logger.info("Tracarbon CLI exited with errors during initialization.")

--- a/tracarbon/exporters/prometheus_exporter.py
+++ b/tracarbon/exporters/prometheus_exporter.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import suppress
 from typing import Any
 from typing import Dict
 
@@ -25,7 +26,8 @@ if PROMETHEUS_INSTALLED:
 
         def __init__(self, **data: Any) -> None:
             super().__init__(**data)
-            prometheus_client.REGISTRY.unregister(prometheus_client.GC_COLLECTOR)
+            with suppress(KeyError):
+                prometheus_client.REGISTRY.unregister(prometheus_client.GC_COLLECTOR)
             addr = self.address if self.address else os.environ.get("PROMETHEUS_ADDRESS", "::")
             port = self.port if self.port else int(os.environ.get("PROMETHEUS_PORT", 8081))
             start_http_server(
@@ -48,7 +50,7 @@ if PROMETHEUS_INSTALLED:
                         [tag.key for tag in metric.tags],
                     )
                 metric_value = await metric.value()
-                if metric_value:
+                if metric_value is not None:
                     await self.add_metric_to_report(metric=metric, value=metric_value)
                     logger.info(
                         f"Sending metric[{metric_name}] with value [{metric_value}] "


### PR DESCRIPTION
# Description
Stabilizes `tracarbon run --exporter-name Prometheus --containers` by preserving zero-valued Prometheus samples, tolerating repeated exporter initialization after the default Prometheus GC collector has already been unregistered, and logging when --containers exits without Kubernetes metrics.
