### PR TITLE
Surface carbon intensity metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ tracarbon.stop()
 with tracarbon:
     # Your code
 
-report = tracarbon.report() # Get the report
+report = tracarbon.report # Get the report
 ```
 
 ## 💻 Development

--- a/tests/carbon_emissions/test_carbon_emissions.py
+++ b/tests/carbon_emissions/test_carbon_emissions.py
@@ -7,6 +7,8 @@ from tracarbon import EnergyUsage
 from tracarbon import LinuxEnergyConsumption
 from tracarbon import MacEnergyConsumption
 from tracarbon import UsageType
+from tracarbon.locations import CarbonIntensityMetadata
+from tracarbon.locations import CarbonIntensitySource
 from tracarbon.locations import Country
 
 
@@ -88,3 +90,24 @@ def test_carbon_usage_with_type_and_conversion():
     assert carbon_usage.get_carbon_usage_on_type(UsageType.MEMORY) == memory_carbon_usage * 1000
     assert carbon_usage.get_carbon_usage_on_type(UsageType.GPU) == gpu_carbon_usage * 1000
     assert carbon_usage.unit == CarbonUsageUnit.CO2_MG
+
+
+@pytest.mark.asyncio
+@pytest.mark.darwin
+async def test_carbon_usage_includes_carbon_intensity_metadata(mocker):
+    co2g_per_kwh = 20.0
+    country = Country(name="fr", co2g_kwh=co2g_per_kwh)
+    mocker.patch.object(
+        MacEnergyConsumption,
+        "get_energy_usage",
+        return_value=EnergyUsage(host_energy_usage=60.0),
+    )
+    carbon_emission = CarbonEmission(location=country)
+
+    carbon_usage = await carbon_emission.get_co2_usage()
+
+    assert carbon_usage.carbon_intensity_metadata == CarbonIntensityMetadata(
+        source=CarbonIntensitySource.FILE,
+        co2g_kwh=co2g_per_kwh,
+        zone="fr",
+    )

--- a/tests/locations/test_country.py
+++ b/tests/locations/test_country.py
@@ -7,6 +7,7 @@ from tracarbon.hardwares.cloud_providers import AWS
 from tracarbon.hardwares.cloud_providers import GCP
 from tracarbon.hardwares.cloud_providers import Azure
 from tracarbon.hardwares.cloud_providers import CloudProviders
+from tracarbon.locations import CarbonIntensityMetadata
 from tracarbon.locations import CarbonIntensitySource
 from tracarbon.locations import Country
 from tracarbon.locations.location import EmissionFactorType
@@ -118,6 +119,17 @@ async def test_electricity_maps_api_v4_lifecycle(mocker):
     assert result == co2_expected
     assert country.co2g_kwh_source == CarbonIntensitySource.ElectricityMapsAPI
     assert country.emission_factor_type == EmissionFactorType.LIFECYCLE
+    assert country.carbon_intensity_metadata == CarbonIntensityMetadata(
+        source=CarbonIntensitySource.ElectricityMapsAPI,
+        co2g_kwh=co2_expected,
+        zone="FR",
+        datetime="2025-01-15T12:00:00.000Z",
+        updated_at="2025-01-15T11:51:02.892Z",
+        emission_factor_type=EmissionFactorType.LIFECYCLE,
+        is_estimated=False,
+        estimation_method=None,
+        fallback_used=False,
+    )
     parsed_url = urlparse(request.call_args.kwargs["url"])
     assert parsed_url.path == "/v4/carbon-intensity/latest"
     assert parse_qs(parsed_url.query) == {
@@ -154,6 +166,31 @@ async def test_electricity_maps_api_v4_direct(mocker):
     assert result == co2_expected
     assert country.emission_factor_type == EmissionFactorType.DIRECT
     assert parse_qs(urlparse(request.call_args.kwargs["url"]).query)["emissionFactorType"] == ["direct"]
+
+
+@pytest.mark.asyncio
+async def test_carbon_intensity_metadata_marks_api_fallback(mocker):
+    co2_expected = 74.0
+    mocker.patch.object(Country, "request", side_effect=RuntimeError("api failed"))
+    country = Country(
+        name="FR",
+        co2signal_api_key="API_KEY",
+        co2signal_url="https://api.electricitymaps.com/v4/carbon-intensity/latest",
+        co2g_kwh=co2_expected,
+        co2g_kwh_source=CarbonIntensitySource.ElectricityMapsAPI,
+        emission_factor_type=EmissionFactorType.LIFECYCLE,
+    )
+
+    result = await country.get_latest_co2g_kwh()
+
+    assert result == co2_expected
+    assert country.carbon_intensity_metadata == CarbonIntensityMetadata(
+        source=CarbonIntensitySource.ElectricityMapsAPI,
+        co2g_kwh=co2_expected,
+        zone="FR",
+        emission_factor_type=EmissionFactorType.LIFECYCLE,
+        fallback_used=True,
+    )
 
 
 @pytest.mark.asyncio

--- a/tracarbon/__init__.py
+++ b/tracarbon/__init__.py
@@ -47,6 +47,7 @@ from tracarbon.hardwares.sensors import Sensor
 from tracarbon.hardwares.sensors import WindowsEnergyConsumption
 from tracarbon.locations import AWSLocation
 from tracarbon.locations import AzureLocation
+from tracarbon.locations import CarbonIntensityMetadata
 from tracarbon.locations import CarbonIntensitySource
 from tracarbon.locations import CloudLocation
 from tracarbon.locations import Country
@@ -77,6 +78,7 @@ __all__ = [
     "CO2SignalAPIKeyIsMissing",
     "CarbonEmission",
     "CarbonEmissionGenerator",
+    "CarbonIntensityMetadata",
     "CarbonIntensitySource",
     "CarbonUsage",
     "CarbonUsageUnit",

--- a/tracarbon/emissions/carbon_emissions.py
+++ b/tracarbon/emissions/carbon_emissions.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from loguru import logger
 from pydantic import BaseModel
+from pydantic import Field
 
 from tracarbon.hardwares import EnergyConsumption
 from tracarbon.hardwares import Power
@@ -11,6 +12,7 @@ from tracarbon.hardwares import Sensor
 from tracarbon.hardwares.energy import EnergyUsage
 from tracarbon.hardwares.energy import EnergyUsageUnit
 from tracarbon.hardwares.energy import UsageType
+from tracarbon.locations import CarbonIntensityMetadata
 from tracarbon.locations import Country
 from tracarbon.locations import Location
 
@@ -34,6 +36,7 @@ class CarbonUsage(BaseModel):
     memory_carbon_usage: float | None = None
     gpu_carbon_usage: float | None = None
     unit: CarbonUsageUnit = CarbonUsageUnit.CO2_G
+    carbon_intensity_metadata: CarbonIntensityMetadata = Field(default_factory=CarbonIntensityMetadata)
 
     def get_carbon_usage_on_type(self, usage_type: UsageType) -> float | None:
         """
@@ -152,4 +155,5 @@ class CarbonEmission(Sensor):
             memory_carbon_usage=(memory_carbon_usage if memory_carbon_usage > 0 else None),
             gpu_carbon_usage=gpu_carbon_usage if gpu_carbon_usage > 0 else None,
             unit=CarbonUsageUnit.CO2_G,
+            carbon_intensity_metadata=self.location.carbon_intensity_metadata.model_copy(),
         )

--- a/tracarbon/locations/__init__.py
+++ b/tracarbon/locations/__init__.py
@@ -3,6 +3,7 @@ from tracarbon.locations.country import AzureLocation
 from tracarbon.locations.country import CloudLocation
 from tracarbon.locations.country import Country
 from tracarbon.locations.country import GCPLocation
+from tracarbon.locations.location import CarbonIntensityMetadata
 from tracarbon.locations.location import CarbonIntensitySource
 from tracarbon.locations.location import EmissionFactorType
 from tracarbon.locations.location import Location
@@ -10,6 +11,7 @@ from tracarbon.locations.location import Location
 __all__ = [
     "AWSLocation",
     "AzureLocation",
+    "CarbonIntensityMetadata",
     "CarbonIntensitySource",
     "CloudLocation",
     "Country",

--- a/tracarbon/locations/country.py
+++ b/tracarbon/locations/country.py
@@ -17,6 +17,7 @@ from tracarbon.hardwares import AWS
 from tracarbon.hardwares import GCP
 from tracarbon.hardwares import Azure
 from tracarbon.hardwares import CloudProviders
+from tracarbon.locations.location import CarbonIntensityMetadata
 from tracarbon.locations.location import CarbonIntensitySource
 from tracarbon.locations.location import EmissionFactorType
 from tracarbon.locations.location import Location
@@ -37,6 +38,27 @@ class Country(Location):
 
     data_center_provider: str | None = None
     data_center_region: str | None = None
+
+    def _update_carbon_intensity_metadata(
+        self,
+        response: dict[str, Any] | None = None,
+        fallback_used: bool = False,
+    ) -> None:
+        payload = response.get("data", response) if response else {}
+        emission_factor_type = payload.get("emissionFactorType")
+        if not emission_factor_type and self.co2g_kwh_source == CarbonIntensitySource.ElectricityMapsAPI:
+            emission_factor_type = self.emission_factor_type.value
+        self.carbon_intensity_metadata = CarbonIntensityMetadata(
+            source=self.co2g_kwh_source,
+            co2g_kwh=self.co2g_kwh,
+            zone=payload.get("zone") or (response or {}).get("countryCode") or self.name,
+            datetime=payload.get("datetime"),
+            updated_at=payload.get("updatedAt"),
+            emission_factor_type=EmissionFactorType(emission_factor_type) if emission_factor_type else None,
+            is_estimated=payload.get("isEstimated"),
+            estimation_method=payload.get("estimationMethod"),
+            fallback_used=fallback_used,
+        )
 
     @classmethod
     def from_eu_file(cls, country_code_alpha_iso_2: str) -> "Country":
@@ -151,6 +173,7 @@ class Country(Location):
         :return: the latest CO2g_kwh
         """
         if self.co2g_kwh_source == CarbonIntensitySource.FILE:
+            self._update_carbon_intensity_metadata()
             return self.co2g_kwh
 
         logger.info(f"Request the latest carbon intensity in Co2g/kwh for your country {self.name}.")
@@ -177,11 +200,14 @@ class Country(Location):
                 headers={"auth-token": self.co2signal_api_key},
             )
             logger.debug(f"Response from the {url}: {response}.")
+            raw_response = response
             if "data" in response:
                 response = response["data"]
             self.co2g_kwh = float(response["carbonIntensity"])
+            self._update_carbon_intensity_metadata(response=raw_response)
             logger.info(f"The latest carbon intensity of your country {self.name} is: {self.co2g_kwh} CO2g/kwh.")
         except Exception:
+            self._update_carbon_intensity_metadata(response=response if response else None, fallback_used=True)
             logger.error(
                 f"Failed to get the latest carbon intensity of your country {self.name} {response if response else ''}."
                 f"Please check your API configuration."
@@ -219,6 +245,7 @@ class AWSLocation(Country):
 
         :return: the latest co2g_kwh
         """
+        self._update_carbon_intensity_metadata()
         return self.co2g_kwh
 
     async def get_co2g_kwh(self) -> float:
@@ -293,6 +320,7 @@ class CloudLocation(Country):
 
         :return: the latest co2g_kwh
         """
+        self._update_carbon_intensity_metadata()
         return self.co2g_kwh
 
     async def get_co2g_kwh(self) -> float:

--- a/tracarbon/locations/location.py
+++ b/tracarbon/locations/location.py
@@ -9,6 +9,7 @@ import orjson
 from aiocache import cached
 from loguru import logger
 from pydantic import BaseModel
+from pydantic import Field
 
 
 class CarbonIntensitySource(str, Enum):
@@ -22,6 +23,22 @@ class EmissionFactorType(str, Enum):
     DIRECT = "direct"
 
 
+class CarbonIntensityMetadata(BaseModel):
+    """
+    Metadata about the carbon intensity value used for emission calculations.
+    """
+
+    source: CarbonIntensitySource = CarbonIntensitySource.FILE
+    co2g_kwh: float | None = None
+    zone: str | None = None
+    datetime: str | None = None
+    updated_at: str | None = None
+    emission_factor_type: EmissionFactorType | None = None
+    is_estimated: bool | None = None
+    estimation_method: str | None = None
+    fallback_used: bool = False
+
+
 class Location(ABC, BaseModel):
     """
     Generic Location.
@@ -33,6 +50,7 @@ class Location(ABC, BaseModel):
     co2signal_url: str | None = None
     co2g_kwh: float = 0.0
     emission_factor_type: EmissionFactorType = EmissionFactorType.LIFECYCLE
+    carbon_intensity_metadata: CarbonIntensityMetadata = Field(default_factory=CarbonIntensityMetadata)
 
     @classmethod
     async def request(cls, url: str, headers: Dict[str, str] | None = None) -> Dict[str, Any]:


### PR DESCRIPTION
# Description
Adds carbon-intensity metadata to carbon-emission results so callers can inspect the value used in the calculation. 
The metadata includes the source, intensity value, zone, Electricity Maps timestamps when present, emission factor type, estimation details, and whether Tracarbon fell back to a locally configured value.